### PR TITLE
FIX: fine-tune-preload links

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -14,79 +14,41 @@
       href="https://fonts.gstatic.com/s/rubikmonoone/v18/UqyJK8kPP3hjw6ANTdfRk9YSN983TKU.woff2"
       as="font"
       type="font/woff2"
-      crossorigin
+      crossorigin="anonymous"
     />
     <link
       rel="preload"
       href="https://fonts.gstatic.com/s/spacemono/v13/i7dPIFZifjKcF5UAWdDRYEF8RQ.woff2"
       as="font"
       type="font/woff2"
-      crossorigin
+      crossorigin="anonymous"
     />
     <link
       rel="preload"
       href="https://fonts.gstatic.com/s/spacemono/v13/i7dMIFZifjKcF5UAWdDRaPpZUFWaHg.woff2"
       as="font"
       type="font/woff2"
-      crossorigin
+      crossorigin="anonymous"
     />
     <link
       rel="preload"
       href="/fonts/UncutSans-Bold.woff2"
       as="font"
       type="font/woff2"
-      crossorigin
+      crossorigin="anonymous"
     />
 
     <!--preload images-->
-    <link
-      rel="preload"
-      href="/stars.avif"
-      as="image"
-      type="image/avif"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/hero.svg"
-      as="image"
-      type="image/svg+xml"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/keyboard.svg"
-      as="image"
-      type="image/svg+xml"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/Screen.svg"
-      as="image"
-      type="image/svg+xml"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/cloud.svg"
-      as="image"
-      type="image/svg+xml"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="/honeymilk.svg"
-      as="image"
-      type="image/svg+xml"
-      crossorigin
-    />
+    <link rel="preload" href="/stars.avif" as="image" type="image/avif" />
+    <link rel="preload" href="/hero.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="/keyboard.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="/Screen.svg" as="image" type="image/svg+xml" />
+    <link rel="preload" href="/honeymilk.svg" as="image" type="image/svg+xml" />
     <link
       rel="preload"
       href="/magic-hand.svg"
       as="image"
       type="image/svg+xml"
-      crossorigin
     />
 
     <style>


### PR DESCRIPTION
This is a follow-up to #1 

It addresses a few warnings the browser throws about preload links.